### PR TITLE
parameters fixed with array structure

### DIFF
--- a/src/webpack/plugin/HtmlWebpackInlineSVGPlugin.js
+++ b/src/webpack/plugin/HtmlWebpackInlineSVGPlugin.js
@@ -457,8 +457,8 @@ class HtmlWebpackInlineSVGPlugin {
     // const config = this.getSvgoConfig();
     // await SVGO.loadConfig(this.getSvgoConfig());
 
-    const result = SVGO.optimize(data, {
-        cleanupIDs: false
+    const result = SVGO.optimize(data, { 
+      plugins: [ { name: 'preset-default', params: { overrides: { cleanupIDs: false }, }, }, ], 
     });
 
     const optimisedSVG = result.data;


### PR DESCRIPTION
Issue:
inline SVG removes ID after injection

Solution:
After looking at the svgo package structure, I notice that svgo.js expects the plugins as an array.

made the following change to the file HtmlWebpackInlineSVGPlugin.js and it works fine.

Replace:

const result = SVGO.optimize(data, { cleanupIDs: false });

To:

const result = SVGO.optimize(data, { plugins: [ { name: 'preset-default', params: { overrides: { cleanupIDs: false }, }, }, ], });