### PR TITLE
setting a publicPath in the output, so it is forced to use "./"

### DIFF
--- a/src/webpack/config/createConfig.js
+++ b/src/webpack/config/createConfig.js
@@ -109,6 +109,7 @@ module.exports = function createConfig({
       //filename: './[name].js',
       filename: richmediarc.settings.useOriginalFileNames ? '[name].js' : "[name]_[contenthash].js",
       path: outputPath,
+      publicPath: './',
       // library: 'someLibName',
       // libraryTarget: 'commonjs',
       iife: false


### PR DESCRIPTION
closes #45
in IE11 the webfontloader loads fonts.css from a wrong base url, this happened due to webpack where it is trying to set the publicPath, its grabbing the last script tag .. which is gsap and getting the url from it here:

function() { var t; __webpack_require__.g.importScripts && (t = __webpack_require__.g.location + ''); var e = __webpack_require__.g.document; if (!t && e && (e.currentScript && (t = e.currentScript.src), !t)) { var n = e.getElementsByTagName('script'); n.length && (t = n[n.length - 1].src); } if (!t) throw new Error('Automatic publicPath is not supported in this browser'); t = t.replace(/#.*$/, '').replace(/\?.*$/, '').replace(/\/[^\/]+$/, '/'), __webpack_require__.p = t; }

also see  https://webpack.js.org/guides/public-path/