### PR TITLE
prevent main.license.txt being created on build

### DIFF
--- a/src/webpack/config/createConfig.js
+++ b/src/webpack/config/createConfig.js
@@ -487,7 +487,9 @@ module.exports = function createConfig({
       chunks: 'async',
     };
 
-    config.optimization.minimizer.push(new TerserPlugin());
+    config.optimization.minimizer.push(new TerserPlugin({
+      extractComments: false
+    }));
 
   } else {
     // standard implementation, no minifying, but removing comments


### PR DESCRIPTION
happens when you use SplitText.js for example, it extracts the license comment and puts this in a separate txt file on build.