### PR TITLE
Feature/73 add quality option for optimizing images

### DIFF
--- a/src/webpack/config/createConfig.js
+++ b/src/webpack/config/createConfig.js
@@ -437,7 +437,7 @@ module.exports = function createConfig({
             outputPath: path.join(outputPath, "../"),
             filename: `${bundleName}.zip`,
             maxFileSize: richmediarc.settings.maxFileSize * 1024,
-            lowestQuality: 60,
+            lowestQuality: richmediarc.settings.lowestImageQuality ? richmediarc.settings.lowestImageQuality : 60,
           })
         : new ZipFilesPlugin({
             outputPath: path.join(outputPath, "../"),

--- a/src/webpack/config/createConfig.js
+++ b/src/webpack/config/createConfig.js
@@ -9,7 +9,7 @@ const sanitizeFilename = require("sanitize-filename");
 
 const WriteFilePlugin = require("../plugin/WriteFilePlugin");
 const ZipFilesPlugin = require("../plugin/ZipFilesPlugin");
-const OptimizeBundleToFilesizePlugin = require('../plugin/OptimizeBundleToFilesizePlugin');
+const OptimizeBundleToFilesizePlugin = require("../plugin/OptimizeBundleToFilesizePlugin");
 const CopyFilesPlugin = require("../plugin/CopyFilesPlugin");
 const HtmlWebpackInlineSVGPlugin = require("../plugin/HtmlWebpackInlineSVGPlugin");
 
@@ -40,7 +40,7 @@ module.exports = function createConfig({
   richmediarcFilepath,
   outputPath,
 
-  options: {mode = DevEnum.DEVELOPMENT, stats = false} = {
+  options: { mode = DevEnum.DEVELOPMENT, stats = false } = {
     mode: DevEnum.DEVELOPMENT,
     stats: false,
   },
@@ -132,7 +132,7 @@ module.exports = function createConfig({
               loaderArray.push({
                 loader: "esbuild-loader",
                 options: {
-                  target: 'es2015'
+                  target: "es2015",
                 },
               });
             }
@@ -271,7 +271,7 @@ module.exports = function createConfig({
               // don't optimize images if optimizeToFileSize is set to true
               imageLoadersArray.push({
                 loader: path.resolve(path.join(__dirname, "../loader/ImageOptimizeLoader.js")),
-                options: {}
+                options: {},
               });
             }
 
@@ -279,21 +279,20 @@ module.exports = function createConfig({
           },
         },
 
-
         {
           test: /\.(ttf|woff|woff2)$/,
           use: [
             richmediarc.settings.fontsBase64
               ? {
-                loader: "url-loader",
-              }
+                  loader: "url-loader",
+                }
               : {
-                loader: "file-loader",
-                options: {
-                  // name: `[name]${namedHashing}.[ext]`,
-                  name: `${namedHashing}.[ext]`,
+                  loader: "file-loader",
+                  options: {
+                    // name: `[name]${namedHashing}.[ext]`,
+                    name: `${namedHashing}.[ext]`,
+                  },
                 },
-              },
             {
               loader: path.resolve(path.join(__dirname, "../loader/RichmediaFontLoader.js")),
               options: {
@@ -359,30 +358,32 @@ module.exports = function createConfig({
   if (fs.existsSync(staticPath)) {
     config.plugins.push(
       new CopyFilesPlugin({
-        fromPath: staticPath
+        fromPath: staticPath,
       })
     );
   }
 
   if (richmediarc.settings.type === "flashtalking") {
-    console.log('found flashtalking ad')
+    console.log("found flashtalking ad");
 
     const outputString = `FT.manifest({
       "filename": "index.html",
       "width": ${richmediarc.settings.size.width},
       "height": ${richmediarc.settings.size.height},
       "clickTagCount": 1
-});`
+});`;
 
-    config.plugins.push(new WriteFilePlugin({
-      filePath: './',
-      fileName: 'manifest.js',
-      content: outputString
-    }))
+    config.plugins.push(
+      new WriteFilePlugin({
+        filePath: "./",
+        fileName: "manifest.js",
+        content: outputString,
+      })
+    );
   }
 
   if (richmediarc.settings.type === "adform") {
-    let clickTags = richmediarc.settings.clickTags || {clickTAG: "http://www.adform.com"};
+    let clickTags = richmediarc.settings.clickTags || { clickTAG: "http://www.adform.com" };
     let obj = {
       version: "1.0",
       title: richmediarc.settings.bundleName || bundleName,
@@ -399,11 +400,13 @@ module.exports = function createConfig({
       source: "index.html",
     };
 
-    config.plugins.push(new WriteFilePlugin({
-      filePath: './',
-      fileName: 'manifest.json',
-      content: JSON.stringify(obj, null, 2)
-    }))
+    config.plugins.push(
+      new WriteFilePlugin({
+        filePath: "./",
+        fileName: "manifest.json",
+        content: JSON.stringify(obj, null, 2),
+      })
+    );
   }
 
   config.optimization = {
@@ -428,19 +431,18 @@ module.exports = function createConfig({
   }
 
   if (mode === DevEnum.PRODUCTION) {
-
     config.plugins.push(
-      richmediarc.settings.optimizeToFileSize ?
-        new OptimizeBundleToFilesizePlugin({
-          outputPath: path.join(outputPath, "../"),
-          filename: `${bundleName}.zip`,
-          maxFileSize: richmediarc.settings.maxFileSize * 1024,
-          lowestQuality: 60,
-        }) :
-        new ZipFilesPlugin({
-          outputPath: path.join(outputPath, "../"),
-          filename: `${bundleName}.zip`
-        })
+      richmediarc.settings.optimizeToFileSize
+        ? new OptimizeBundleToFilesizePlugin({
+            outputPath: path.join(outputPath, "../"),
+            filename: `${bundleName}.zip`,
+            maxFileSize: richmediarc.settings.maxFileSize * 1024,
+            lowestQuality: 60,
+          })
+        : new ZipFilesPlugin({
+            outputPath: path.join(outputPath, "../"),
+            filename: `${bundleName}.zip`,
+          })
     );
   }
 


### PR DESCRIPTION
If you add **lowestImageQuality** to your settings in the .sharedrc config and describe a quality percentage (default is 60) you can set the quality of the image compression lower or higher, example:

```
  "settings": {
    "browserSupport": [
      "> 1%",
      "not ie 11"
    ],
    "maxFileSize": 20,
    "optimizeToFileSize": true,
    "lowestImageQuality": 20
}
```
For testing: 
- checkout mediamonks/display-dev-server
- switch to my for and then to this feature branch
- in this branch, type `npm link` and `npm install`
- create a new banner, by running `yo display-boilerplate` and `npm install`
- then type your newly created setup folder: `npm link path-to-feature-branch` ie `npm C:\Users\paulie\git\m\mediamonks\da-framework\display-dev-server`
- if all has been tested, in your display-dev-server folder, type `npm unlink` to get back your original display-dev-server rather than my forked one :) 