### PR TITLE
Fixes sync version of path resolver ("" -> folder name of config) ==> ("" -> "")

### DIFF
--- a/src/util/getRichmediaRCSync.js
+++ b/src/util/getRichmediaRCSync.js
@@ -30,7 +30,8 @@ module.exports = function getRichmediaRCSync(filepath, onDependecy = () => {}) {
     if (typeof value === 'string'
       && !isExternalURL(value)
       && !path.isAbsolute(value)
-      && fs.existsSync(path.resolve(dirname, value)))
+      && fs.existsSync(path.resolve(dirname, value))
+      && value !== '')
     {
       obj[name] = path.resolve(dirname, value);
     }


### PR DESCRIPTION
Noticed that CSS vars contained an old bug with empty path names.