### PR TITLE
chore: release version 11.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [11.7.0] - 2024-03-27
+
+### Added
+- Custom info chips for banner metadata
+- GSDevTools keyboard toggle (G+S)
+- SASS support
+- Favicon and brand logo integration
+
+### Improved
+- URL parameter handling
+- SVG optimization settings
+
+### Technical
+- Updated GitHub Actions workflow
+- Improved CI/CD pipeline configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mediamonks/display-dev-server",
-  "version": "11.6.2",
+  "version": "11.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mediamonks/display-dev-server",
-      "version": "11.6.2",
+      "version": "11.7.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediamonks/display-dev-server",
-  "version": "11.6.3",
+  "version": "11.7.0",
   "description": "This is the Display.Monks development server, which handles previewing and compiling ads via webpack.",
   "scripts": {
     "preview-dev": "cd ./src/preview && npm run dev",


### PR DESCRIPTION
Hi team! 
So this is what we should do to upgrade and add all the new features and fixed we been merging so far.
I ll add a CHANGELOG file as well to have all of them explained, and to keep track of what is new in the tool.

The main update here is 
# Version 11.7.0

## New Features
- Custom info chips for banner metadata
- GSDevTools keyboard toggle (G+S)
- SASS support
- Favicon and brand logo integration

## Improvements
- URL parameter handling
- SVG optimization settings
- Updated GitHub Actions workflow

## Changes
- Bumped version from 11.6.3 to 11.7.0
- Updated changelog
- Updated CI/CD configuration

## Testing
- [ ] Version number correctly updated
- [ ] Changelog is accurate and complete
- [ ] All new features working as expected